### PR TITLE
fix(deserialize): decode merchant parameters one by one, allowing for decode failures in case a paremeter value is not encoded

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,7 +1,16 @@
 import { expectType } from 'ts-expect';
 import type { TypeEqual } from 'ts-expect';
 
-import type { UrlsConfig, SANDBOX_URLS, PRODUCTION_URLS } from './client';
+import type { UrlsConfig, PRODUCTION_URLS } from './client';
+import { createRedsysAPI, SANDBOX_URLS } from './client';
+
+import {
+  redirectWithDccMerchantKey,
+  serializedRestNotificationWithDcc,
+  deserializedRestNotificationWithDcc,
+  serializedRedirectNotificationWithDcc,
+  deserializedRedirectNotificationWithDcc
+} from '../test/fixtures/rest/redirect-dcc';
 
 describe('UrlsConfig', () => {
   it('should match type of default urls', () => {
@@ -9,4 +18,58 @@ describe('UrlsConfig', () => {
 
     expectType<TypeEqual<UrlsConfig, typeof PRODUCTION_URLS>>(true);
   });
+});
+
+describe('processRedirectNotification', () => {
+
+  it('should decode x-www-form-urlencoded characters', () => {
+    const {
+      processRedirectNotification: processRedirectRestNotification
+    } = createRedsysAPI({
+      secretKey: redirectWithDccMerchantKey,
+      urls: SANDBOX_URLS
+    });
+
+    expect(
+      processRedirectRestNotification(serializedRedirectNotificationWithDcc)
+    ).toEqual(deserializedRedirectNotificationWithDcc);
+  });
+});
+
+describe('processDirectRestNotification', () => {
+
+  it('should decode DCC notification', () => {
+    const {
+      processDirectRestNotification
+    } = createRedsysAPI({
+      secretKey: redirectWithDccMerchantKey,
+      urls: SANDBOX_URLS
+    });
+
+    expect(
+      processDirectRestNotification(serializedRestNotificationWithDcc)
+    ).toEqual(deserializedRestNotificationWithDcc);
+  });
+
+});
+
+describe('processRestNotification', () => {
+
+  it('should process both direct and redirect notifications', () => {
+    const {
+      processRestNotification
+    } = createRedsysAPI({
+      secretKey: redirectWithDccMerchantKey,
+      urls: SANDBOX_URLS
+    });
+
+    expect(
+      processRestNotification(serializedRestNotificationWithDcc)
+    ).toEqual(deserializedRestNotificationWithDcc);
+
+    expect(
+      processRestNotification(serializedRedirectNotificationWithDcc)
+    ).toEqual(deserializedRedirectNotificationWithDcc);
+  });
+
 });

--- a/src/crypto.test.ts
+++ b/src/crypto.test.ts
@@ -7,8 +7,8 @@ import {
   redirectRequest,
   redirectRequest3DESOrder,
   serializedAndSignedRedirectRequest,
-  serializedRestNotification,
-  deserializedRestNotification
+  serializedRedirectRestNotification,
+  deserializedRedirectRestNotification
 } from '../test/fixtures/rest/redirect';
 
 import {
@@ -107,7 +107,7 @@ describe('Crypto', () => {
       ).toEqual(Buffer.from(redirectWithIdentifier3DESOrder, 'base64'));
 
       expect(
-        encrypt3DES(redirectMerchantKey, deserializedRestNotification.Ds_Order)
+        encrypt3DES(redirectMerchantKey, deserializedRedirectRestNotification.Ds_Order)
       ).toEqual(Buffer.from(redirectRequest3DESOrder, 'base64'));
 
       expect(
@@ -173,13 +173,13 @@ describe('Crypto', () => {
       expect(
         sha256Sign(
           redirectMerchantKey,
-          deserializedRestNotification.Ds_Order,
-          serializedRestNotification.Ds_MerchantParameters
+          deserializedRedirectRestNotification.Ds_Order,
+          serializedRedirectRestNotification.Ds_MerchantParameters
         )
         // Redsys returns base64url encoded instead of regular base64
       ).toEqual(
         base64url
-          .toBuffer(serializedRestNotification.Ds_Signature)
+          .toBuffer(serializedRedirectRestNotification.Ds_Signature)
           .toString('base64')
       );
 

--- a/src/formatter-utils.test.ts
+++ b/src/formatter-utils.test.ts
@@ -45,7 +45,8 @@ const {
   restIniciaPeticion,
   restTrataPeticion,
   createRedirectForm,
-  processRestNotification,
+  processRedirectNotification: processRedirectRestNotification,
+  processDirectRestNotification,
   processSoapNotification
 } = createRedsysAPI({
   secretKey: 'sq7HjrUOBfKmC576ILgskD5srU870gJ7',
@@ -117,8 +118,8 @@ describe('Formatter utils interfaces', () => {
   });
 
   it('should work with rest notification formatters', () => {
-    const wrappedFormatter = useOutputFormatter(
-      processRestNotification,
+    const wrappedUrlFormatter = useOutputFormatter(
+      processRedirectRestNotification,
       restNotificationOutputFormatter
     );
 
@@ -127,7 +128,21 @@ describe('Formatter utils interfaces', () => {
         (
           input: ResponseJSONSuccess
         ) => NotificationFormatterOutput<RestNotificationOutputParams>,
-        typeof wrappedFormatter
+        typeof wrappedUrlFormatter
+      >
+    >(true);
+
+    const wrappedDirectRestNotificationFormatter = useOutputFormatter(
+      processDirectRestNotification,
+      restNotificationOutputFormatter
+    );
+
+    expectType<
+      TypeEqual<
+        (
+          input: ResponseJSONSuccess
+        ) => NotificationFormatterOutput<RestNotificationOutputParams>,
+        typeof wrappedDirectRestNotificationFormatter
       >
     >(true);
   });

--- a/src/rest/json-serialization.test.ts
+++ b/src/rest/json-serialization.test.ts
@@ -6,8 +6,6 @@ import {
 import {
   redirectRequest,
   serializedRedirectRequest,
-  serializedRestNotification,
-  deserializedRestNotification
 } from '../../test/fixtures/rest/redirect';
 
 import {
@@ -16,10 +14,17 @@ import {
 } from '../../test/fixtures/rest/redirect-identifier';
 
 import {
+  serializedRestNotificationWithDcc,
+  deserializedRestNotificationWithDcc,
+} from '../../test/fixtures/rest/redirect-dcc';
+
+import {
   iniciaPeticionRequest as iniciaPeticionV1Request,
   serializedAndSignedIniciaPeticionRequest as serializedAndSignedIniciaPeticionV1Request,
   searializedInicaPeticionResponse as searializedInicaPeticionV1Response,
-  deserializedIniciaPeticionResponse as deserializedIniciaPeticionV1Response
+  deserializedIniciaPeticionResponse as deserializedIniciaPeticionV1Response,
+  serializedAuthDataResponse as searializedAuthDataV1Response,
+  deserializedAuthDataResponse as deserializedAuthDataV1Response
 } from '../../test/fixtures/rest/3ds-v1';
 
 import {
@@ -51,9 +56,9 @@ describe('REST JSON serialization', () => {
   it('should deserialize merchant parameters', () => {
     expect(
       deserializeJSONMerchantParams(
-        serializedRestNotification.Ds_MerchantParameters
+        serializedRestNotificationWithDcc.Ds_MerchantParameters
       )
-    ).toEqual(deserializedRestNotification);
+    ).toEqual(deserializedRestNotificationWithDcc);
 
     expect(
       deserializeJSONMerchantParams(
@@ -68,34 +73,11 @@ describe('REST JSON serialization', () => {
     ).toEqual(deserializedIniciaPeticionV1Response);
   });
 
-  it('correctly deserializes merchant params dates', () => {
+  it('should decode auth data', () => {
     expect(
       deserializeJSONMerchantParams(
-        Buffer.from(
-          JSON.stringify({ Ds_Date: '23%2F06%2F2024', Ds_Hour: '12%3A30' })
-        ).toString('base64')
+        searializedAuthDataV1Response.Ds_MerchantParameters
       )
-    ).toEqual({
-      Ds_Date: '23/06/2024',
-      Ds_Hour: '12:30'
-    });
-  });
-
-  it('correctly deserializes merchant params with markup percentage', () => {
-    expect(
-      deserializeJSONMerchantParams(
-        Buffer.from(
-          JSON.stringify({
-            Ds_Date: '23%2F06%2F2024',
-            Ds_Hour: '12%3A30',
-            Ds_Markup_DCC: '5.5%'
-          })
-        ).toString('base64')
-      )
-    ).toEqual({
-      Ds_Date: '23/06/2024',
-      Ds_Hour: '12:30',
-      Ds_Markup_DCC: '5.5%'
-    });
+    ).toEqual(deserializedAuthDataV1Response);
   });
 });

--- a/src/rest/json-serialization.test.ts
+++ b/src/rest/json-serialization.test.ts
@@ -67,4 +67,35 @@ describe('REST JSON serialization', () => {
       )
     ).toEqual(deserializedIniciaPeticionV1Response);
   });
+
+  it('correctly deserializes merchant params dates', () => {
+    expect(
+      deserializeJSONMerchantParams(
+        Buffer.from(
+          JSON.stringify({ Ds_Date: '23%2F06%2F2024', Ds_Hour: '12%3A30' })
+        ).toString('base64')
+      )
+    ).toEqual({
+      Ds_Date: '23/06/2024',
+      Ds_Hour: '12:30'
+    });
+  });
+
+  it('correctly deserializes merchant params with markup percentage', () => {
+    expect(
+      deserializeJSONMerchantParams(
+        Buffer.from(
+          JSON.stringify({
+            Ds_Date: '23%2F06%2F2024',
+            Ds_Hour: '12%3A30',
+            Ds_Markup_DCC: '5.5%'
+          })
+        ).toString('base64')
+      )
+    ).toEqual({
+      Ds_Date: '23/06/2024',
+      Ds_Hour: '12:30',
+      Ds_Markup_DCC: '5.5%'
+    });
+  });
 });

--- a/src/rest/json-serialization.ts
+++ b/src/rest/json-serialization.ts
@@ -13,11 +13,20 @@ export const deserializeJSONMerchantParams = <
     throw new ParseError('Payload must be a base-64 encoded string');
   }
   const payload = JSON.parse(
-    decodeURIComponent(Buffer.from(strPayload, 'base64').toString('utf8'))
+    Buffer.from(strPayload, 'base64').toString('utf8')
   ) as DeserializedResponseParams | null | undefined;
 
   if (typeof payload !== 'object' || payload == null) {
     throw new ParseError('Cannot parse notification payload');
+  }
+
+  const payloadObj = payload as Record<string, unknown>;
+  for (const key of Object.keys(payload)) {
+    const value = payloadObj[key];
+    if (typeof value !== 'string') continue;
+    try {
+      payloadObj[key] = decodeURIComponent(value);
+    } catch (e) {}
   }
 
   return payload;

--- a/src/rest/json-serialization.ts
+++ b/src/rest/json-serialization.ts
@@ -20,15 +20,6 @@ export const deserializeJSONMerchantParams = <
     throw new ParseError('Cannot parse notification payload');
   }
 
-  const payloadObj = payload as Record<string, unknown>;
-  for (const key of Object.keys(payload)) {
-    const value = payloadObj[key];
-    if (typeof value !== 'string') continue;
-    try {
-      payloadObj[key] = decodeURIComponent(value);
-    } catch (e) {}
-  }
-
   return payload;
 };
 

--- a/src/rest/json-sha256-signature.test.ts
+++ b/src/rest/json-sha256-signature.test.ts
@@ -12,8 +12,8 @@ import {
   redirectRequest,
   serializedRedirectRequest,
   serializedAndSignedRedirectRequest,
-  serializedRestNotification,
-  deserializedRestNotification
+  serializedRedirectRestNotification,
+  deserializedRedirectRestNotification
 } from '../../test/fixtures/rest/redirect';
 
 import {
@@ -63,8 +63,8 @@ describe('REST JSON SHA256 signature', () => {
     expect(() =>
       sha256VerifyJSONResponse(
         redirectMerchantKey,
-        serializedRestNotification,
-        deserializedRestNotification
+        serializedRedirectRestNotification,
+        deserializedRedirectRestNotification
       )
     ).not.toThrowError();
 
@@ -81,8 +81,8 @@ describe('REST JSON SHA256 signature', () => {
     expect(() =>
       sha256VerifyJSONResponse(
         incorrectMerchantKey,
-        serializedRestNotification,
-        deserializedRestNotification
+        serializedRedirectRestNotification,
+        deserializedRedirectRestNotification
       )
     ).toThrowError(new ParseError('Invalid signature'));
 
@@ -100,10 +100,10 @@ describe('REST JSON SHA256 signature', () => {
       sha256VerifyJSONResponse(
         redirectMerchantKey,
         {
-          ...serializedRestNotification,
+          ...serializedRedirectRestNotification,
           Ds_Signature: '7DVpRPAPoChZh2cgaWnLqlfFsKeXdRfAO_tz-UrxJcU='
         },
-        deserializedRestNotification
+        deserializedRedirectRestNotification
       )
     ).toThrowError(new ParseError('Invalid signature'));
 
@@ -124,10 +124,10 @@ describe('REST JSON SHA256 signature', () => {
       sha256VerifyJSONResponse(
         redirectMerchantKey,
         {
-          ...serializedRestNotification,
+          ...serializedRedirectRestNotification,
           Ds_SignatureVersion: 'None'
         },
-        deserializedRestNotification
+        deserializedRedirectRestNotification
       )
     ).toThrowError(new RedsysError('Unknown signature version: None'));
 

--- a/src/rest/json.test.ts
+++ b/src/rest/json.test.ts
@@ -11,8 +11,7 @@ import {
   redirectMerchantKey,
   redirectRequest,
   serializedAndSignedRedirectRequest,
-  serializedRestNotification,
-  deserializedRestNotification
+  serializedRedirectRestNotification
 } from '../../test/fixtures/rest/redirect';
 
 import {
@@ -30,6 +29,11 @@ import {
   serializedChallengeResponseResponse,
   deserializedChallengeResponseResponse
 } from '../../test/fixtures/rest/3ds-v2.1-challenge';
+
+import {
+  serializedRestNotificationWithDcc,
+  deserializedRestNotificationWithDcc,
+} from '../../test/fixtures/rest/redirect-dcc';
 
 describe('REST JSON', () => {
   describe('SHA256', () => {
@@ -54,9 +58,9 @@ describe('REST JSON', () => {
       expect(
         deserializeAndVerifyJSONResponse(
           redirectMerchantKey,
-          serializedRestNotification
+          serializedRestNotificationWithDcc
         )
-      ).toEqual(deserializedRestNotification);
+      ).toEqual(deserializedRestNotificationWithDcc);
 
       expect(
         deserializeAndVerifyJSONResponse(
@@ -77,7 +81,7 @@ describe('REST JSON', () => {
       expect(() =>
         deserializeAndVerifyJSONResponse(
           incorrectMerchantKey,
-          serializedRestNotification
+          serializedRedirectRestNotification
         )
       ).toThrowError(new ParseError('Invalid signature'));
 
@@ -92,7 +96,7 @@ describe('REST JSON', () => {
     it('should fail to verify response if signature is forged', () => {
       expect(() =>
         deserializeAndVerifyJSONResponse(redirectMerchantKey, {
-          ...serializedRestNotification,
+          ...serializedRedirectRestNotification,
           Ds_Signature: '7DVpRPAPoChZh2cgaWnLqlfFsKeXdRfAO_tz-UrxJcU='
         })
       ).toThrowError(new ParseError('Invalid signature'));
@@ -108,7 +112,7 @@ describe('REST JSON', () => {
     it('should fail to verify response if signature version is unknown', () => {
       expect(() =>
         deserializeAndVerifyJSONResponse(redirectMerchantKey, {
-          ...serializedRestNotification,
+          ...serializedRedirectRestNotification,
           Ds_SignatureVersion: 'None'
         })
       ).toThrowError(new RedsysError('Unknown signature version: None'));

--- a/src/rest/utils.test.ts
+++ b/src/rest/utils.test.ts
@@ -1,0 +1,19 @@
+import { decodeUrlEntries } from './utils';
+
+describe('decodeUrlEntries', () => {
+
+  it('correctly deserializes merchant params with markup percentage', () => {
+    expect(
+      decodeUrlEntries({
+        Ds_Date: '23%2F06%2F2024',
+        Ds_Hour: '12%3A30',
+        Ds_Markup_DCC: '5.5%'
+      })
+    ).toEqual({
+      Ds_Date: '23/06/2024',
+      Ds_Hour: '12:30',
+      Ds_Markup_DCC: '5.5%'
+    });
+  });
+
+});

--- a/src/rest/utils.ts
+++ b/src/rest/utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Tries to decode x-www-form-urlencoded values of an object
+ */
+export const decodeUrlEntries = <T extends object>(
+  params: T
+): T => {
+    return Object.fromEntries(
+      Object.entries(params).map((entry) => {
+        let processedValue: unknown = entry[1];
+
+        if (typeof entry[1] === 'string') {
+          try {
+            processedValue = decodeURIComponent(entry[1].replaceAll('+', ' '));
+          } catch (_) {}
+        }
+
+        return [entry[0], processedValue];
+      })
+    ) as unknown as T;
+};

--- a/src/types/output-params.test.ts
+++ b/src/types/output-params.test.ts
@@ -10,7 +10,7 @@ import type {
 
 import type { deserializedRestJsonResponse } from '../../test/fixtures/rest/rest-json';
 
-import type { deserializedRestNotification } from '../../test/fixtures/rest/redirect';
+import type { deserializedRedirectRestNotification } from '../../test/fixtures/rest/redirect';
 
 import type { deserializedRestNotificationWithIdentifier } from '../../test/fixtures/rest/redirect-identifier';
 
@@ -94,7 +94,7 @@ describe('RestTrataPeticionOutputParams', () => {
 describe('RestNotificationOutputParams', () => {
   it('should match real data', () => {
     expectType<
-      TypeOf<RestNotificationOutputParams, typeof deserializedRestNotification>
+      TypeOf<RestNotificationOutputParams, typeof deserializedRedirectRestNotification>
     >(true);
 
     expectType<

--- a/test/fixtures/formatters/rest-notification.ts
+++ b/test/fixtures/formatters/rest-notification.ts
@@ -1,11 +1,11 @@
 import {
-  deserializedRestNotification
+  deserializedRedirectRestNotification
 } from '../rest/redirect';
 
 export {
   redirectMerchantKey,
-  serializedRestNotification,
-  deserializedRestNotification
+  serializedRedirectRestNotification as serializedRestNotification,
+  deserializedRedirectRestNotification as deserializedRestNotification
 } from '../rest/redirect';
 
 export const formattedRestNotification = {
@@ -24,5 +24,5 @@ export const formattedRestNotification = {
   cardCountry: 'es',
   lang: 'es',
   cardBrand: 'VISA',
-  raw: deserializedRestNotification
+  raw: deserializedRedirectRestNotification
 };

--- a/test/fixtures/rest/redirect-dcc.ts
+++ b/test/fixtures/rest/redirect-dcc.ts
@@ -1,0 +1,72 @@
+export const redirectWithDccMerchantKey = 'sq7HjrUOBfKmC576ILgskD5srU870gJ7';
+
+export const serializedRestNotificationWithDcc = {
+  Ds_SignatureVersion: 'HMAC_SHA256_V1',
+  Ds_MerchantParameters:
+    'eyJEc19NZXJjaGFudENvZGUiOiI5OTkwMDg4ODEiLCJEc19UZXJtaW5hbCI6IjAwMSIsIkRzX09yZGVyIjoiOTc2OGR1R1VSUjFMIiwiRHNfQW1vdW50IjoiNDk5OSIsIkRzX0N1cnJlbmN5IjoiOTc4IiwiRHNfRGF0ZSI6IjI4XC8wNlwvMjAyNCIsIkRzX0hvdXIiOiIyMzoyMyIsIkRzX1NlY3VyZVBheW1lbnQiOiIxIiwiRHNfQ2FyZF9OdW1iZXIiOiI0MTE3NzMqKioqKio3ODkxIiwiRHNfQ2FyZF9Db3VudHJ5IjoiODQwIiwiRHNfUmVzcG9uc2UiOiIwMDAwIiwiRHNfTWVyY2hhbnREYXRhIjoiIiwiRHNfVHJhbnNhY3Rpb25UeXBlIjoiMCIsIkRzX0NvbnN1bWVyTGFuZ3VhZ2UiOiIxIiwiRHNfQXV0aG9yaXNhdGlvbkNvZGUiOiIwMTMzNzgiLCJEc19DYXJkX0JyYW5kIjoiMSIsIkRzX1Byb2Nlc3NlZFBheU1ldGhvZCI6Ijc4IiwiRHNfQ3VycmVuY3lfRENDIjoiODQwIiwiRHNfQW1vdW50X0RDQyI6IjU4NDAiLCJEc19DdXJyZW5jeU5hbWVfRENDIjoiRE9MQVIgVS5TLkEuIiwiRHNfTWFya3VwX0RDQyI6IjMuMCIsIkRzX0V4Y2hhbmdlUmF0ZV9EQ0MiOiIwLjg4MTYwOSIsIkRzX0VDSSI6IjA1IiwiRHNfUmVzcG9uc2VfRGVzY3JpcHRpb24iOiJPUEVSQUNJT04gQVVUT1JJWkFEQSJ9',
+  Ds_Signature: 'cgLd-6DO0wqoalRidsHdaAu69kzj8HVebBvHJdklYZA='
+};
+
+export const deserializedRestNotificationWithDcc = {
+  Ds_MerchantCode: '999008881',
+  Ds_Terminal: '001',
+  Ds_Order: '9768duGURR1L',
+  Ds_Amount: '4999',
+  Ds_Currency: '978',
+  // prettier-ignore
+  // eslint-disable-next-line no-useless-escape
+  Ds_Date: '28\/06\/2024',
+  Ds_Hour: '23:23',
+  Ds_SecurePayment: '1',
+  Ds_Card_Number: '411773******7891',
+  Ds_Card_Country: '840',
+  Ds_Response: '0000',
+  Ds_MerchantData: '',
+  Ds_TransactionType: '0',
+  Ds_ConsumerLanguage: '1',
+  Ds_AuthorisationCode: '013378',
+  Ds_Card_Brand: '1',
+  Ds_ProcessedPayMethod: '78',
+  Ds_Currency_DCC: '840',
+  Ds_Amount_DCC: '5840',
+  Ds_CurrencyName_DCC: 'DOLAR U.S.A.',
+  Ds_Markup_DCC: '3.0',
+  Ds_ExchangeRate_DCC: '0.881609',
+  Ds_ECI: '05',
+  Ds_Response_Description: 'OPERACION AUTORIZADA'
+} as const;
+
+export const serializedRedirectNotificationWithDcc = {
+  Ds_SignatureVersion: 'HMAC_SHA256_V1',
+  Ds_MerchantParameters:
+    'eyJEc19EYXRlIjoiMjglMkYwNiUyRjIwMjQiLCJEc19Ib3VyIjoiMjMlM0EyMyIsIkRzX1NlY3VyZVBheW1lbnQiOiIxIiwiRHNfQW1vdW50IjoiNDk5OSIsIkRzX0N1cnJlbmN5IjoiOTc4IiwiRHNfT3JkZXIiOiI5NzY4ZHVHVVJSMUwiLCJEc19NZXJjaGFudENvZGUiOiI5OTkwMDg4ODEiLCJEc19UZXJtaW5hbCI6IjAwMSIsIkRzX1Jlc3BvbnNlIjoiMDAwMCIsIkRzX1RyYW5zYWN0aW9uVHlwZSI6IjAiLCJEc19NZXJjaGFudERhdGEiOiIiLCJEc19BdXRob3Jpc2F0aW9uQ29kZSI6IjAxMzM3OCIsIkRzX0NhcmRfTnVtYmVyIjoiNDExNzczKioqKioqNzg5MSIsIkRzX0NvbnN1bWVyTGFuZ3VhZ2UiOiIxIiwiRHNfQ2FyZF9Db3VudHJ5IjoiODQwIiwiRHNfQ2FyZF9CcmFuZCI6IjEiLCJEc19Qcm9jZXNzZWRQYXlNZXRob2QiOiI3OCIsIkRzX0VDSSI6IjA1IiwiRHNfUmVzcG9uc2VfRGVzY3JpcHRpb24iOiJPUEVSQUNJT04rQVVUT1JJWkFEQSIsIkRzX0NvbnRyb2xfMTcxOTYwOTgyODU5NSI6IjE3MTk2MDk4Mjg1OTUiLCJEc19DdXJyZW5jeV9EQ0MiOiI4NDAiLCJEc19BbW91bnRfRENDIjoiNTg0MCIsIkRzX0N1cnJlbmN5TmFtZV9EQ0MiOiJET0xBUitVLlMuQS4iLCJEc19NYXJrdXBfRENDIjoiMy4wJTI1IiwiRHNfRXhjaGFuZ2VSYXRlX0RDQyI6IjAuODgxNjA5In0=',
+  Ds_Signature: 'KDb9Gu69g7VHfWtx9kg10eq6Yyz1TSuUyqiWcBir93I='
+} as const;
+
+export const deserializedRedirectNotificationWithDcc = {
+  Ds_Date: '28/06/2024',
+  Ds_Hour: '23:23',
+  Ds_SecurePayment: '1',
+  Ds_Amount: '4999',
+  Ds_Currency: '978',
+  Ds_Order: '9768duGURR1L',
+  Ds_MerchantCode: '999008881',
+  Ds_Terminal: '001',
+  Ds_Response: '0000',
+  Ds_TransactionType: '0',
+  Ds_MerchantData: '',
+  Ds_AuthorisationCode: '013378',
+  Ds_Card_Number: '411773******7891',
+  Ds_ConsumerLanguage: '1',
+  Ds_Card_Country: '840',
+  Ds_Card_Brand: '1',
+  Ds_ProcessedPayMethod: '78',
+  Ds_ECI: '05',
+  Ds_Response_Description: 'OPERACION AUTORIZADA',
+  Ds_Control_1719609828595: '1719609828595',
+  Ds_Currency_DCC: '840',
+  Ds_Amount_DCC: '5840',
+  Ds_CurrencyName_DCC: 'DOLAR U.S.A.',
+  Ds_Markup_DCC: '3.0%',
+  Ds_ExchangeRate_DCC: '0.881609'
+} as const;

--- a/test/fixtures/rest/redirect.ts
+++ b/test/fixtures/rest/redirect.ts
@@ -22,13 +22,13 @@ export const serializedAndSignedRedirectRequest = {
   Ds_Signature: 'TyW+LIa2GZnhCPLM7JSPwbQn4ZjOvMO/KiIf4yJgwo8='
 };
 
-export const serializedRestNotification = {
+export const serializedRedirectRestNotification = {
   Ds_SignatureVersion: 'HMAC_SHA256_V1',
   Ds_MerchantParameters: 'eyJEc19EYXRlIjoiMjIlMkYxMCUyRjIwMjEiLCJEc19Ib3VyIjoiMjIlM0E1MSIsIkRzX1NlY3VyZVBheW1lbnQiOiIxIiwiRHNfQ2FyZF9OdW1iZXIiOiI0NTQ4ODEqKioqKiowMDA0IiwiRHNfQ2FyZF9Db3VudHJ5IjoiNzI0IiwiRHNfQW1vdW50IjoiNDk5OSIsIkRzX0N1cnJlbmN5IjoiOTc4IiwiRHNfT3JkZXIiOiIwNzI2cUkzSDdzWngiLCJEc19NZXJjaGFudENvZGUiOiI5OTkwMDg4ODEiLCJEc19UZXJtaW5hbCI6IjAwMSIsIkRzX1Jlc3BvbnNlIjoiMDAwMCIsIkRzX01lcmNoYW50RGF0YSI6IiIsIkRzX1RyYW5zYWN0aW9uVHlwZSI6IjAiLCJEc19Db25zdW1lckxhbmd1YWdlIjoiMSIsIkRzX0F1dGhvcmlzYXRpb25Db2RlIjoiMDUyMDI5IiwiRHNfQ2FyZF9CcmFuZCI6IjEiLCJEc19Qcm9jZXNzZWRQYXlNZXRob2QiOiIxIn0=',
   Ds_Signature: '52nPyUkyDws__OfMqDka_yN-arxzulELZC1TYTvvR0s='
 };
 
-export const deserializedRestNotification = {
+export const deserializedRedirectRestNotification = {
   Ds_Date: '22/10/2021',
   Ds_Hour: '22:51',
   Ds_SecurePayment: '1',

--- a/test/integration/redirection/redirection.test.ts
+++ b/test/integration/redirection/redirection.test.ts
@@ -37,7 +37,7 @@ const { URL } = url;
 
 const {
   createRedirectForm,
-  processRestNotification
+  processDirectRestNotification
 } = createRedsysAPI({
   urls: SANDBOX_URLS,
   secretKey
@@ -296,7 +296,7 @@ describe('Redirect Integration', () => {
     expect(body).not.toBeNull();
     expect(serverCtx.href).toEqual(redirectData.merchantURL);
 
-    const params = processRestNotification(body);
+    const params = processDirectRestNotification(body);
     expect(params.Ds_Response).toEqual('0000');
   });
 


### PR DESCRIPTION
This PR solves an issue we've encountered in production that's been causing us some problems.

```
URIError: URI malformed
        at decodeURIComponent (<anonymous>)
```

Redsys appears to encode only the values of certain fields within the merchant parameters data. However, this library attempts to decode the entire JSON string, which can lead to decoding errors in runtime (and payment processing failure).
Specifically, when Redsys includes the `Ds_Markup_DCC` value in their response we've observed that this value typical follows the format `5.5%`. The fact that this value includes a `%` sign, causes a `URIError: URI malformed` error when decodeURIComponent is called on the entire merchant data json string.

This PR modifies `deserializeJSONMerchantParams`, removing the global decoding and instead decoding each value one by one.

As Redsys seems to really only encode the values of `Ds_Date` and `Ds_Hour`, a better implementation might be one that only decodes those two properties and doesn't attempt to decode any others. But due to my lack of understanding on the matter and not knowing if there are any other values that may be encoded. I've decided to take the safe route and simply `try-catch` to decode each property value (assuming it's a string).

I've added two new tests specifically made to test the decoding behavior of the `deserializeJSONMerchantParams` method.


